### PR TITLE
增加vip.163.com邮箱支持

### DIFF
--- a/libs/Mail.php
+++ b/libs/Mail.php
@@ -44,6 +44,10 @@ class Mail
                 $host = 'smtp.163.com';
                 $secure = 'ssl';
                 $port = 465;
+            } else if (stripos($username, '@vip.163.com') !== false) {
+                $host = 'smtp.vip.163.com';
+                $secure = 'ssl';
+                $port = 465;
             } else {
                 throw new \Exception('不受支持的邮箱。目前仅支持谷歌邮箱、QQ邮箱以及163邮箱，推荐使用谷歌邮箱。');
             }


### PR DESCRIPTION
基本设置（POP3/SMTP服务和IMAP/SMTP服务）与163邮箱一样，不过vip邮箱不需要申请客户端授权密码，直接和gmail邮箱一样使用账户加密码的方式登录即可。