### PR TITLE
添加Telegram api自建反向代理地址参数

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ ENV_FILE_VERSION='v2.2'
 
 ######################  账户配置 Account config  #########################
 # Freenom 账户 Freenom Account
-FREENOM_USERNAME=593198779@qq.com
+FREENOM_USERNAME=''
 
 # Freenom 密码 Freenom password
 FREENOM_PASSWORD=''
@@ -30,7 +30,7 @@ FREENOM_PROXY=''
 
 ######################  通知邮件配置 Email config  #########################
 # 机器人邮箱账户 Email of robot
-MAIL_USERNAME=llf.push@gmail.com
+MAIL_USERNAME=''
 
 # 机器人邮箱密码（Gmail填密码，QQ邮箱或163邮箱填授权码） Password of the robot email
 MAIL_PASSWORD=''
@@ -39,7 +39,7 @@ MAIL_PASSWORD=''
 TO=''
 
 # 是否启用邮件推送功能 1：启用 0：不启用 Whether to enable email push features 1: enabled 0: not enabled
-MAIL_ENABLE=1
+MAIL_ENABLE=0
 
 # 自定义邮箱配置 Custom email config
 # 如果你想使用除 “QQ邮箱、163邮箱、Gmail、Outlook邮箱” 外的第三方邮箱或者自建邮箱服务作为机器人邮箱，可以自定义邮箱配置，否则请不要配置这些项
@@ -70,6 +70,11 @@ TELEGRAM_BOT_TOKEN=''
 
 # Telegram 代理 e.g. http://127.0.0.1:1081 or socks5://127.0.0.1:1080
 TELEGRAM_PROXY=''
+
+## Telegram api自建反向代理地址（选填）
+## 教程：https://www.hostloc.com/thread-805441-1-1.html
+## 如反向代理地址 http://aaa.bbb.ccc 则填写 aaa.bbb.ccc
+TELEGRAM_API_HOST=''
 
 # 是否启用 Telegram Bot 功能 1：启用 0：不启用 Whether to enable Telegram Bot features 1: enabled 0: not enabled
 TELEGRAM_BOT_ENABLE=0

--- a/config.php
+++ b/config.php
@@ -43,6 +43,7 @@ return [
             'class' => \Luolongfei\Libs\MessageServices\TelegramBot::class,
             'name' => lang('100065'),
             'proxy' => env('TELEGRAM_PROXY'),
+            'host' => env('TELEGRAM_API_HOST'),
         ],
 
         /**

--- a/libs/MessageServices/TelegramBot.php
+++ b/libs/MessageServices/TelegramBot.php
@@ -28,6 +28,11 @@ class TelegramBot extends MessageGateway
     protected $token;
 
     /**
+     * @var host TELEGRAM_API_HOST
+     */
+    protected $host;
+
+    /**
      * @var Client
      */
     protected $client;
@@ -36,6 +41,7 @@ class TelegramBot extends MessageGateway
     {
         $this->chatID = config('message.telegram.chat_id');
         $this->token = config('message.telegram.token');
+        $this->host = config('message.telegram.host') ?: 'api.telegram.org';
 
         $this->client = new Client([
             'headers' => [
@@ -272,7 +278,7 @@ class TelegramBot extends MessageGateway
 
         try {
             $resp = $this->client->post(
-                sprintf('https://api.telegram.org/bot%s/sendMessage', $this->token),
+                sprintf('https://%s/bot%s/sendMessage', $this->host, $this->token),
                 [
                     'form_params' => [
                         'chat_id' => $recipient ? $recipient : $this->chatID,


### PR DESCRIPTION
## Telegram api自建反向代理地址（选填）
## 教程：https://www.hostloc.com/thread-805441-1-1.html
## 如反向代理地址 http://aaa.bbb.ccc 则填写 aaa.bbb.ccc
`TELEGRAM_API_HOST=''
`