### PR TITLE
修复日志权限不足

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -97,7 +97,8 @@ if (!function_exists('system_log')) {
                 $file = $path . ($fileName ?: date('d')) . '.log';
 
                 if (!is_dir($path)) {
-                    mkdir($path, 0666, true); // 0666 所有用户可读写
+                    mkdir($path, 0766, true); // 0766 赋予所有用户读写
+                    chmod($path, 0766);    // 显式 chmod 确保权限设置正确
                 }
 
                 $handle = fopen($file, 'a'); // 追加而非覆盖


### PR DESCRIPTION
https://github.com/luolongfei/freenom/issues/154

导致该问题的原因：观察到 mkdir 指定权限为 0666，但实际创建出来的 logs/Y-m 目录权限为 0644

以下是GPT给的解释，作为参考原因吧

>从输出结果来看，虽然在脚本中指定了目录权限为 0666，但实际创建的目录权限是 0644。这是因为大多数系统都会应用 umask 来限制文件和目录的默认权限。
>
>umask 是一个系统级别的设置，用于确定新创建的文件和目录的默认权限。它指定了权限应该被去掉的位。例如，如果 umask 是 022，默认权限 0666 将被减去 022，得到的权限是 0644。
>
>如果需要特定的权限，可以在 mkdir 之后使用 chmod 函数显式地设置权限

另外经测试，0666 权限仍然会导致非 root 用户无足够的日志文件写入权限，故改为 0766

解决方案：
1. mkdir 后进行一次 chmod
2. 0666 → 0766

使用方式（以www-data用户为例）：

```sh
sudo chown -R www-data:www-data freenom
cd freenom
sudo -u www-data php run
```